### PR TITLE
Fix bugs in README and function examples

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,7 +1,6 @@
-^\.gitlab-ci\.yml$
+^\.github
 ^.*\.Rproj$
 ^\.Rproj\.user$
 ^pkgdown/*
 ^README\.Rmd$
-
 ^LICENSE\.md$

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 inst/doc
+.Rproj.user

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,5 +32,5 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 VignetteBuilder: knitr

--- a/R/srcref_df.R
+++ b/R/srcref_df.R
@@ -20,8 +20,14 @@
 #' }
 #'
 #' @examples
-#' as.data.frame(pkg_srcrefs("covtracer"))
-#'
+#' pkg <- system.file("examplepkg", package = "covtracer")
+#' remotes::install_local(
+#'   pkg, 
+#'   force = TRUE, 
+#'   quiet = TRUE, 
+#'   INSTALL_opts = "--with-keep.source"
+#' )
+#' as.data.frame(pkg_srcrefs("examplepkg"))
 #' @export
 as.data.frame.list_of_srcref <- function(x, ..., use.names = TRUE,
     expand.srcref = FALSE, row.names = NULL) {
@@ -67,7 +73,14 @@ as.data.frame.list_of_srcref <- function(x, ..., use.names = TRUE,
 #' }
 #'
 #' @examples
-#' pkg_srcrefs_df("covtracer")
+#' pkg <- system.file("examplepkg", package = "covtracer")
+#' remotes::install_local(
+#'   pkg, 
+#'   force = TRUE, 
+#'   quiet = TRUE, 
+#'   INSTALL_opts = "--with-keep.source"
+#' )
+#' pkg_srcrefs_df("examplepkg")
 #'
 #' @family srcrefs_df
 #' @seealso srcrefs test_trace_mapping

--- a/R/srcrefs.R
+++ b/R/srcrefs.R
@@ -149,8 +149,14 @@ flat_map_srcrefs <- function(xs) {
 #'   namespace available in the current environment is used.
 #'
 #' @examples
-#' # requires package to have been installed with --with-keep.source flag
-#' pkg_srcrefs("covtracer")
+#' pkg <- system.file("examplepkg", package = "covtracer")
+#' remotes::install_local(
+#'   pkg, 
+#'   force = TRUE, 
+#'   quiet = TRUE, 
+#'   INSTALL_opts = "--with-keep.source"
+#' )
+#' pkg_srcrefs("examplepkg")
 #'
 #' @family srcrefs
 #' @seealso as.data.frame.list_of_srcref
@@ -196,7 +202,7 @@ pkg_srcrefs.coverage <- function(x) {
 #'
 #' Test whether the package object collection contains srcref attributes.
 #'
-#' @param a package namespace environment or iterable collection of package
+#' @param env A package namespace environment or iterable collection of package
 #'   objects
 #'
 package_check_has_keep_source <- function(env) {

--- a/README.Rmd
+++ b/README.Rmd
@@ -75,9 +75,13 @@ library(covr)
 library(remotes)
 
 withr::with_temp_libpaths({
-  options(keep.source = TRUE, keep.source.pkg = TRUE)
   pkg <- system.file("examplepkg", package = "covtracer")
-  remotes::install_local(pkg, force = TRUE, quiet = TRUE)
+  remotes::install_local(
+    pkg, 
+    force = TRUE, 
+    quiet = TRUE, 
+    INSTALL_opts = "--with-keep.source"
+  )
 
   options(covr.record_tests = TRUE)
   cov <- covr::package_coverage(pkg)

--- a/README.md
+++ b/README.md
@@ -55,9 +55,13 @@ library(covr)
 library(remotes)
 
 withr::with_temp_libpaths({
-  options(keep.source = TRUE, keep.source.pkg = TRUE)
   pkg <- system.file("examplepkg", package = "covtracer")
-  remotes::install_local(pkg, force = TRUE, quiet = TRUE)
+  remotes::install_local(
+    pkg, 
+    force = TRUE, 
+    quiet = TRUE, 
+    INSTALL_opts = "--with-keep.source"
+  )
 
   options(covr.record_tests = TRUE)
   cov <- covr::package_coverage(pkg)

--- a/covtracer.Rproj
+++ b/covtracer.Rproj
@@ -1,0 +1,17 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source

--- a/man/as.data.frame.list_of_srcref.Rd
+++ b/man/as.data.frame.list_of_srcref.Rd
@@ -44,6 +44,12 @@ the numeric components of the \code{srcref} objects if \code{expand.srcrefs
 Coerce a list_of_srcref object to a data.frame
 }
 \examples{
-as.data.frame(pkg_srcrefs("covtracer"))
-
+pkg <- system.file("examplepkg", package = "covtracer")
+remotes::install_local(
+  pkg, 
+  force = TRUE, 
+  quiet = TRUE, 
+  INSTALL_opts = "--with-keep.source"
+)
+as.data.frame(pkg_srcrefs("examplepkg"))
 }

--- a/man/package_check_has_keep_source.Rd
+++ b/man/package_check_has_keep_source.Rd
@@ -7,7 +7,7 @@
 package_check_has_keep_source(env)
 }
 \arguments{
-\item{a}{package namespace environment or iterable collection of package
+\item{env}{A package namespace environment or iterable collection of package
 objects}
 }
 \description{

--- a/man/pkg_srcrefs.Rd
+++ b/man/pkg_srcrefs.Rd
@@ -23,8 +23,14 @@ the name of the package used is extracted.}
 Extract all the srcref objects of objects within a package namespace
 }
 \examples{
-# requires package to have been installed with --with-keep.source flag
-pkg_srcrefs("covtracer")
+pkg <- system.file("examplepkg", package = "covtracer")
+remotes::install_local(
+  pkg, 
+  force = TRUE, 
+  quiet = TRUE, 
+  INSTALL_opts = "--with-keep.source"
+)
+pkg_srcrefs("examplepkg")
 
 }
 \seealso{

--- a/man/pkg_srcrefs_df.Rd
+++ b/man/pkg_srcrefs_df.Rd
@@ -23,7 +23,14 @@ variables:
 Create a data.frame of package srcref objects
 }
 \examples{
-pkg_srcrefs_df("covtracer")
+pkg <- system.file("examplepkg", package = "covtracer")
+remotes::install_local(
+  pkg, 
+  force = TRUE, 
+  quiet = TRUE, 
+  INSTALL_opts = "--with-keep.source"
+)
+pkg_srcrefs_df("examplepkg")
 
 }
 \seealso{


### PR DESCRIPTION
`R CMD check` seems to install covtracer without setting `--with-keep.source`. This causes the examples to fail when run on `covtracer`. I changed examples to run on `examplepkg` and added `INSTALL_opts = "--with-keep.source"` in `install_local` in the README.