### PR TITLE
Adding fallback for unnamed items in pkg namespace (Resolves #8)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,5 +32,5 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 VignetteBuilder: knitr

--- a/R/srcrefs.R
+++ b/R/srcrefs.R
@@ -123,14 +123,14 @@ flat_map_srcrefs <- function(xs) {
   srcs <- mapply(
     function(i, ...) srcrefs(i, ...),
     xs,
-    srcref_names = names(xs),
+    srcref_names = names(xs) %||% rep_len("", length(xs)),
     SIMPLIFY = FALSE
   )
 
   srcnames <- mapply(
     function(new, old) names(new) %||% rep_len(old, length(new)),
     srcs,
-    names(srcs),
+    names(srcs) %||% rep_len("", length(srcs)),
     SIMPLIFY = FALSE
   )
 


### PR DESCRIPTION
Some namespace objects contain unnamed lists, which would previously cause errors due to using `mapply` over unevenly length lists. Now, missing names are replaced with a character vector of empty names, allowing it to continue.