### PR TITLE
Handling method table definitions from reexports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: covtracer
 Title: Tools for contextualizing tests
-Version: 0.0.0.9002
+Version: 0.0.0.9003
 Authors@R: c(
     person(
       given = "Doug",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # Unreleased (tentative 0.0.1)
 
+* Resolve bug with reepxort methods S3 tables (#31, @dgkf)
+
+* Remove unnecessary recursion when searching for object's namespace (#31, @dgkf)
+
 * Added test description handling for namespaced `testthat::test_that` calls.
 
 * Updated to include field `is_reexported`, denoting whether the package object

--- a/R/obj_namespace_name.R
+++ b/R/obj_namespace_name.R
@@ -27,8 +27,7 @@ obj_namespace_name.default <- function(x, ns) {
 obj_namespace_name.character <- function(x, ns) {
   is_exported <- x %in% getNamespaceExports(ns)
   if (!is_exported) return(NA_character_)
-  x <- getExportedValue(ns, x)
-  obj_namespace_name(x, ns)
+  env_ns_name(environment(getExportedValue(ns, x)))
 }
 
 #' @exportS3Method

--- a/R/srcrefs.R
+++ b/R/srcrefs.R
@@ -110,6 +110,9 @@ srcrefs.R6ClassGenerator <- function(x, ..., srcref_names = NULL) {
 #' @importFrom utils getSrcref
 #' @rdname srcrefs
 srcrefs.MethodDefinition <- function(x, ..., srcref_names = NULL) {
+  # catch methods in methods tables from packages without srcref data
+  if (is.null(sr <- getSrcref(x))) return(x)
+
   # as produced by `methods:::.methods_info`
   signatures <- paste0(x@generic, ",", paste0(x@defined, collapse = ","), "-method")
   signatures <- signatures[!duplicated(signatures)]

--- a/R/srcrefs.R
+++ b/R/srcrefs.R
@@ -111,7 +111,7 @@ srcrefs.R6ClassGenerator <- function(x, ..., srcref_names = NULL) {
 #' @rdname srcrefs
 srcrefs.MethodDefinition <- function(x, ..., srcref_names = NULL) {
   # catch methods in methods tables from packages without srcref data
-  if (is.null(sr <- getSrcref(x))) return(x)
+  if (is.null(sr <- getSrcref(x))) return(sr)
 
   # as produced by `methods:::.methods_info`
   signatures <- paste0(x@generic, ",", paste0(x@defined, collapse = ","), "-method")


### PR DESCRIPTION
Resolves #31

There were two issues that surfaced when running `covtracer` against the `VGAM` package

### 1. Reexport methods tables

The first error

```
Error in attr(objs[[i]], "namespace") <- ns 
attempt to set an attribute on NULL
```
We can simply short-circuit this behavior by returning `NULL` (without attributes) when `getSrcref(x)` is null. This will get filtered out from the package srcref index either way.

Occurs when a method definition has no srcref. In `VGAM`, this occurs because methods tables incorporate some methods from `stats`. I didn't dig much further into the exact cause or how frequently this would happen (it might be more widespread, affecting any method implemented on a generic from a package built without srcrefs) because the fix should handle any such cases anyways.

### 2. Object namespace fetching from character vectors

The second 

```
'if (!is_exported) return(NA_character_)':
 the condition has length > 1 and only the first element will be used
 ```
Was due to an edge case I never considered. When a package exports a character vector (in the case of `VGAM`, a vector of color codes), we then recurse through the vector to look for the value namespace. Neither the exported vector nor its individual elements will return a value for `environment()`, and they aren't executable package code anyways. 
 
We really don't need recursion here (recursing through exports happens in `pkg_srcrefs`), so I just removed it and we only return the namespace associated with objects as they were discovered in `pkg_srcrefs`. 