### PR TITLE
Filtering NULL srcrefs; suppressing test install output

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: covtracer
 Title: Tools for contextualizing tests
-Version: 0.0.0.9003
+Version: 0.0.0.9004
 Authors@R: c(
     person(
       given = "Doug",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # Unreleased (tentative 0.0.1)
 
+* Resolve edge-case bug where all nested namespace objects are without srcrefs
+  (#33, @dgkf)
+
 * Resolve bug with reepxort methods S3 tables (#31, @dgkf)
 
 * Remove unnecessary recursion when searching for object's namespace (#31, @dgkf)

--- a/R/srcrefs.R
+++ b/R/srcrefs.R
@@ -140,6 +140,9 @@ flat_map_srcrefs <- function(xs, ns = NULL) {
     SIMPLIFY = FALSE
   )
 
+  # remove NULL srcrefs, otherwise they cause problematic unlisting.
+  srcs <- Filter(Negate(is.null), srcs)
+
   srcnames <- mapply(
     function(new, old) names(new) %||% rep_len(old, length(new)),
     srcs,

--- a/tests/testthat/setup_test_packages.R
+++ b/tests/testthat/setup_test_packages.R
@@ -31,7 +31,8 @@ for (i in seq_along(pkg_dirs)) {
     lib = lib,
     repos = NULL,
     dependencies = FALSE,
-    INSTALL_opts = c("--with-keep.source", "--install-tests")
+    INSTALL_opts = c("--with-keep.source", "--install-tests"),
+    quiet = TRUE
   )
 }
 


### PR DESCRIPTION
Closes #33

This addresses a bug where `NULL` srcrefs (returned when no relevant source code is associated with an object), would be `unlist`ed into a singular `NULL` object in cases where all recursive srcrefs were `NULL`.

To address this, we filter the `NULL`s out before we attempt to assign names to them to avoid unlisting issues.
