### PR TITLE
Avoid parsing srcrefs when unnecessary (Resolves #40)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: covtracer
 Title: Tools for contextualizing tests
-Version: 0.0.0.9004
+Version: 0.0.0.9005
 Authors@R: c(
     person(
       given = "Doug",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # Unreleased (tentative 0.0.1)
 
+* Avoid parsing srcrefs when they're only needed for producing a test
+  description string, instead just jumping straight to coersion to string (#41,
+  @dgkf)
+
 * Added safety fuse for extracting srcrefs of cyclic recursive environment
   nesting, terminating when beginning to recurse into an environment that has
   already been hit (#38, @dkgf)

--- a/R/test_description.R
+++ b/R/test_description.R
@@ -27,7 +27,7 @@ test_description.default <- function(x) {
 #' @exportS3Method
 test_description.srcref <- function(x) {
   keystr <- paste0("[", getSrcFilename(x), "#L", as.numeric(x)[1], "] ")
-  test_description(paste0(keystr, expr_str(srcref_expr(x))))
+  test_description(paste0(keystr, srcref_str(x)))
 }
 
 #' @exportS3Method
@@ -87,7 +87,17 @@ test_description_test_that <- function(x, ...) {
 #' @param ref a \code{srcref}
 #'
 srcref_expr <- function(ref) {
-  parse(text = as.character(ref))
+  parse(text = srcref_str(ref))
+}
+
+
+
+#' Parse the expression associated with a srcref
+#'
+#' @param ref a \code{srcref}
+#'
+srcref_str <- function(ref) {
+  paste0(as.character(ref), collapse = "\n")
 }
 
 


### PR DESCRIPTION
A fix for a case discovered when testing `Biobase`, in which case incremental parsing of lines would result in a syntax error due to missing curly braces around `if-else` blocks. 

It turns out we didn't really need to parse this at all, so now we just coerce to string directly, which avoids any parsing issues whatsoever. 