### PR TITLE
Updating tests to reflect covr test mat type

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: covtracer
 Title: Tools for contextualizing tests
-Version: 0.0.0.9007
+Version: 0.0.0.9008
 Authors@R: c(
     person(
       given = "Doug",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # Unreleased (tentative 0.0.1)
 
+* Minor changes to internal test matrix type to use `integer` instead of
+  `numeric` (`double`), coinciding with changes to upstream `covr`. (#47, @dgkf)
+
 * Added column `type` to the result of `test_srcrefs_df` and thereby `test_type`
   to the result of `test_trace_df` to provide contextual information necessary
   for interpretting the test descriptions (#43, @dgkf)

--- a/R/srcref_df.R
+++ b/R/srcref_df.R
@@ -247,17 +247,24 @@ test_trace_mapping <- function(x) {
 
   # if no tests are present, return first available matrix with 0 rows
   if (!any(has_tests)) {
-    empty_result <- matrix(numeric(0L), ncol = 4L,
-      dimnames = list(c(), c("test", "depth", "i", "trace")))
+    empty_result <- matrix(
+      integer(0L),
+      ncol = 4L,
+      dimnames = list(c(), c("test", "depth", "i", "trace"))
+    )
+
     return(empty_result)
   }
 
   mat <- do.call(
     rbind,
-    mapply(function(i, covi) cbind(covi$tests, trace = i),
+    mapply(
+      function(i, covi) cbind(covi$tests, trace = i),
       seq_along(x)[has_tests],
       x[has_tests],
-      SIMPLIFY = FALSE))
+      SIMPLIFY = FALSE
+    )
+  )
 
   mat <- mat[order(mat[, "test"], mat[, "i"]),, drop = FALSE]
   mat

--- a/tests/testthat/test_trace_mapping.R
+++ b/tests/testthat/test_trace_mapping.R
@@ -2,7 +2,8 @@ test_that("test trace mapping", {
   cases <- list(
     "combines coverage trace matrices" = examplepkg_cov,
     "produces a matrix from a single trace" = examplepkg_cov[1L],
-    "produces an empty matrix from no traces" = examplepkg_cov[c()])
+    "produces an empty matrix from no traces" = examplepkg_cov[c()]
+  )
 
   expect_true(all(vapply(cases, inherits, logical(1L), "coverage")))
 
@@ -11,7 +12,7 @@ test_that("test trace mapping", {
     test_that(names(cases)[[i]], {
       cov_data <- cases[[i]]
       expect_silent(ttmat <- test_trace_mapping(cov_data))
-      expect_type(ttmat, "double")
+      expect_type(ttmat, "integer")
       expect_true(length(dim(ttmat)) == 2L)
       expect_true(ncol(ttmat) == ncol(examplepkg_cov[[1L]]$tests) + 1L)
       expect_true(all(colnames(ttmat) == c(colnames(examplepkg_cov[[1L]]$tests), "trace")))


### PR DESCRIPTION
Updates fallback types in `covtracer` to match `covr`, updates tests to expect `integer` matrices. Functionally, this should not impact `covtracer` at all.