### PR TITLE
Fixing bug with srcref-less pkg objects

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: covtracer
 Title: Tools for contextualizing tests
-Version: 0.0.0.9008
+Version: 0.0.0.9009
 Authors@R: c(
     person(
       given = "Doug",
@@ -42,5 +42,5 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.0
+RoxygenNote: 7.2.1
 VignetteBuilder: knitr

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # Unreleased (tentative 0.0.1)
 
+* Fix bug when producing a test-trace data.frame when package objects have an
+  empty `srcfile`. This can happen when an object is documented, such as a
+  `list`, which does not preserve a `srcref` (#51, @dgkf)
+
 * Minor changes to internal test matrix type to use `integer` instead of
   `numeric` (`double`), coinciding with changes to upstream `covr`. (#47, @dgkf)
 

--- a/R/srcref_df.R
+++ b/R/srcref_df.R
@@ -303,7 +303,7 @@ match_containing_srcrefs <- function(l, r) {
 
   while (li <= nrow(ldf) && ri <= nrow(rdf)) {
     # if filenames don't match, jump to filename
-    if ((t <- basename(ldf[[li, "srcfile"]])) != basename(rdf[[ri, "srcfile"]])) {
+    if (!identical(t <- basename(ldf[[li, "srcfile"]]), basename(rdf[[ri, "srcfile"]]))) {
       p <- Position(function(i) identical(i, t), basename(rdf[ri:nrow(rdf), "srcfile"]))
       if (is.na(p)) {
         # no srcrefs from the same file, no chance of being contained, iterate


### PR DESCRIPTION
Closes #51 

In the package `officer`, we encountered a situation where a package object was documented, but contained no relevant `srcrefs`. In this case, it was a [`list` object](https://github.com/davidgohel/officer/blob/b2004ab2ea6853f8ea5f6f96fcf879b85de8533f/R/shorcuts.R#L18). 

The fix was straightforward - to use `identical` instead of `==` for comparing `srcfile`s when merging tests and trace data.frames.