### PR TITLE
Update expr_str

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: covtracer
 Title: Tools for contextualizing tests
-Version: 0.0.0.9013
+Version: 0.0.0.9014
 Authors@R: c(
       person(
         given = "Doug",

--- a/NEWS.md
+++ b/NEWS.md
@@ -45,3 +45,5 @@
 * Adding initial test-trace data.frame constructors (@dgkf)
 
 * Skip classes not used for dispatch in `srcrefs.list` (@maksymiuks)
+
+* Add symbols handling to `expr_str` (@maksymiuks)

--- a/R/test_description.R
+++ b/R/test_description.R
@@ -182,12 +182,15 @@ srcref_str <- function(ref) {
 
 
 
-#' Convert an expression or call to a single-line string
+#' Convert an expression, call or symbol to a single-line string
 #'
 #' @param ref a \code{srcref}
 #'
 expr_str <- function(ref) {
   # special case naked generic calls (see: inst/examplepkg/tests/non-testthat.R)
+  if (is.symbol(ref)) {
+    return(paste0("symbol: ", as.character(ref)))
+  }
   if (inherits(ref[[1]], "standardGeneric")) {
     return(paste0("S4 Generic Call: ", format_standardGeneric_call(ref)))
   }

--- a/R/test_description.R
+++ b/R/test_description.R
@@ -187,10 +187,12 @@ srcref_str <- function(ref) {
 #' @param ref a \code{srcref}
 #'
 expr_str <- function(ref) {
-  # special case naked generic calls (see: inst/examplepkg/tests/non-testthat.R)
+  # used when description of the test is given by a variable 
+  # (see: inst/examplepkg/tests/testthat/test-complex-calls.R)
   if (is.symbol(ref)) {
     return(paste0("symbol: ", as.character(ref)))
   }
+  # special case naked generic calls (see: inst/examplepkg/tests/non-testthat.R)
   if (inherits(ref[[1]], "standardGeneric")) {
     return(paste0("S4 Generic Call: ", format_standardGeneric_call(ref)))
   }

--- a/inst/examplepkg/tests/testthat/test-complex-calls.R
+++ b/inst/examplepkg/tests/testthat/test-complex-calls.R
@@ -5,3 +5,14 @@ test_that("Calling a deeply nested series of functions.", {
 test_that("Calling a function halfway through call stack.", {
   expect_equal(deeper_nested_function("test"), "test")
 })
+
+local({
+  descriptions <- as.character(1:10)
+  for (i in seq_along(descriptions)) {
+    desc <- descriptions[i]
+    
+    test_that(desc, {
+      expect_equal(complex_call_stack("test"), "test")
+    })
+  }
+})

--- a/man/expr_str.Rd
+++ b/man/expr_str.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/test_description.R
 \name{expr_str}
 \alias{expr_str}
-\title{Convert an expression or call to a single-line string}
+\title{Convert an expression, call or symbol to a single-line string}
 \usage{
 expr_str(ref)
 }
@@ -10,5 +10,5 @@ expr_str(ref)
 \item{ref}{a \code{srcref}}
 }
 \description{
-Convert an expression or call to a single-line string
+Convert an expression, call or symbol to a single-line string
 }


### PR DESCRIPTION
Quick hotfix to also handle symbols. Issue discovered when running rlang package.