### PR TITLE
fix: pkg srcrefs df building without package objects

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ Imports:
 Suggests:
     testthat,
     remotes,
-    covr (>= 3.5.1.9003),
+    covr (>= 3.5.2),
     withr,
     R6,
     cli,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: covtracer
 Title: Tools for contextualizing tests
-Version: 0.0.0.9014
+Version: 0.0.0.9015
 Authors@R: c(
       person(
         given = "Doug",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # Unreleased (tentative 0.0.1)
 
+* Fix handling for packages with no objects (#73, @dgkf)
+
 * Add handling for `testthat`'s `describe`-`it` syntax (#63, @dgkf)
 
 * Improve handling of non-function package object aliases (#61, @dgkf)

--- a/R/srcref_df.R
+++ b/R/srcref_df.R
@@ -90,7 +90,7 @@ pkg_srcrefs_df <- function(x) {
   srcs <- pkg_srcrefs(x)
   df <- as.data.frame(srcs)
   has_srcref <- vapply(df$srcref, inherits, logical(1L), "srcref")
-  df$namespace <- NA_character_
+  df$namespace[] <- NA_character_
 
   df$namespace[has_srcref] <- vapply(
     srcs[has_srcref],

--- a/R/srcref_df.R
+++ b/R/srcref_df.R
@@ -90,16 +90,16 @@ pkg_srcrefs_df <- function(x) {
   srcs <- pkg_srcrefs(x)
   df <- as.data.frame(srcs)
   has_srcref <- vapply(df$srcref, inherits, logical(1L), "srcref")
-  df$namespace[] <- NA_character_
+  df[, "namespace"] <- NA_character_
 
-  df$namespace[has_srcref] <- vapply(
+  df[has_srcref, "namespace"] <- vapply(
     srcs[has_srcref],
     attr,
     character(1L),
     "namespace"
   )
 
-  df$namespace[!has_srcref] <- vapply(
+  df[!has_srcref, "namespace"] <- vapply(
     df$name[!has_srcref],
     obj_namespace_name,
     character(1L),

--- a/R/utils.R
+++ b/R/utils.R
@@ -15,7 +15,7 @@
 get_namespace_object_names <- function(ns) {
   out <- getNamespaceExports(ns)
   # filter private S4 methods tables and class definitions
-  out[!grepl("^\\.__(T|C)__", out)]
+  out[!grepl("^\\.__[TC]__", out)]
 }
 
 
@@ -24,7 +24,7 @@ get_namespace_object_names <- function(ns) {
 #'
 #' @importFrom utils packageVersion
 new_empty_test_trace_tally <- function() {
-  if (utils::packageVersion("covr") < "3.6.3") {
+  if (utils::packageVersion("covr") < "3.6.4.9000") {
     matrix(
       integer(0L),
       ncol = 4L,

--- a/R/utils.R
+++ b/R/utils.R
@@ -24,7 +24,8 @@ get_namespace_object_names <- function(ns) {
 #'
 #' @importFrom utils packageVersion
 new_empty_test_trace_tally <- function() {
-  if (utils::packageVersion("covr") < "3.6.4.9000") {
+  # version needs to be updated until changes are merged
+  if (utils::packageVersion("covr") <= "3.6.4.9000") {
     matrix(
       integer(0L),
       ncol = 4L,


### PR DESCRIPTION
A classic R pitfall. A variation of

```r
> df <- data.frame()
> df$x <- "something"
# Error in `$<-.data.frame`(`*tmp*`, x, value = "something") :
#  replacement has 1 row, data has 0
```

And to fix, we just index by `[]`:

```r
> df <- data.frame()
> df[, "x"] <- "something"
> df
# [1] x
# <0 rows> (or 0-length row.names)
```